### PR TITLE
Make progress bar same color as checkboxes.

### DIFF
--- a/app/src/main/res/drawable/watched_progress.xml
+++ b/app/src/main/res/drawable/watched_progress.xml
@@ -4,7 +4,7 @@
       android:id="@android:id/background" >
     <shape>
       <solid
-          android:color="@color/grey"/>
+          android:color="@color/primary_material_light"/>
     </shape>
   </item>
   <item
@@ -12,7 +12,7 @@
     <clip>
       <shape>
         <solid
-            android:color="@color/blue"/>
+            android:color="@color/accent_material_light"/>
       </shape>
     </clip>
   </item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <color name="blue">#33B5E5</color>
-  <color name="grey">#ADADAD</color>
-</resources>


### PR DESCRIPTION
Changes the "watched" progress bar colors to built in ones, so that colors.xml could be removed again.
The foreground is now the same as the checkboxes and "selected tab" underline.
The background was changed to the primary background color for the theme to be able to remove colors.xml and for better contrast with the text.
Not sure if this is interesting or not, but I'm doing it for my version so thought I'd at least show it.

Before <==> After
<img src="https://cloud.githubusercontent.com/assets/3090888/5516302/4e512172-8895-11e4-880a-a9a33fe2ab60.png" width="40%" /> <img src="https://cloud.githubusercontent.com/assets/3090888/5516303/4e5442e4-8895-11e4-908d-00801ac95fc5.png" width="40%" />

By the way, I noticed that the indention in watched_progress.xml is spaces, not tabs.
