### PR TITLE
Add support for sorting seasons list in descending order

### DIFF
--- a/app/src/main/java/org/jamienicol/episodes/EpisodesCounter.java
+++ b/app/src/main/java/org/jamienicol/episodes/EpisodesCounter.java
@@ -17,11 +17,15 @@
 
 package org.jamienicol.episodes;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.database.Cursor;
 import android.util.SparseIntArray;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
+import org.jamienicol.episodes.Preferences;
 import org.jamienicol.episodes.db.EpisodesTable;
 
 public class EpisodesCounter
@@ -35,7 +39,15 @@ public class EpisodesCounter
 	public EpisodesCounter(String keyColumn) {
 		this.keyColumn = keyColumn;
 
-		keys = new TreeSet<Integer>();
+		SharedPreferences preferences = Preferences.getSharedPreferences();
+
+		if (preferences.getBoolean("reverse_sort_order", false)) {
+			keys = new TreeSet<Integer>(Collections.reverseOrder());
+		} else {
+			keys = new TreeSet<Integer>();
+		}
+
+		// keys = new TreeSet<Integer>();
 		numAiredEpisodesMap = new SparseIntArray();
 		numWatchedEpisodesMap = new SparseIntArray();
 		numUpcomingEpisodesMap = new SparseIntArray();

--- a/app/src/main/java/org/jamienicol/episodes/MainActivity.java
+++ b/app/src/main/java/org/jamienicol/episodes/MainActivity.java
@@ -34,16 +34,24 @@ public class MainActivity
 	implements ShowsListFragment.OnShowSelectedListener,
 	           SelectBackupDialog.OnBackupSelectedListener
 {
+	private static Context context;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.main_activity);
 
+		MainActivity.context = getApplicationContext();
+
 		// ensure that the auto-refresh alarm is scheduled.
 		// this should mainly be useful the first time the app is ran.
 		AutoRefreshHelper.getInstance(getApplicationContext())
 			.rescheduleAlarm();
+	}
+
+	public static Context getAppContext() {
+		return MainActivity.context;
 	}
 
 	@Override

--- a/app/src/main/java/org/jamienicol/episodes/Preferences.java
+++ b/app/src/main/java/org/jamienicol/episodes/Preferences.java
@@ -1,0 +1,13 @@
+package org.jamienicol.episodes;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+public class Preferences {
+
+	public static SharedPreferences getSharedPreferences() {
+		Context context = MainActivity.getAppContext();
+		return PreferenceManager.getDefaultSharedPreferences(context);
+	}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,8 @@
   <string name="pref_auto_refresh_period_title">Refresh frequency</string>
   <string name="pref_auto_refresh_enabled_title">Auto-refresh library</string>
   <string name="pref_auto_refresh_wifi_only_title">Refresh only via Wi-Fi</string>
+  <string name="pref_reverse_sort_order">Reverse sort order</string>
+  <string name="pref_reverse_sort_order_summary">Display newest season first</string>
   <string name="restore_dialog_no_backups_message">No backups found in folder \'%s\'.</string>
   <string name="restore_dialog_title">Restore from backup</string>
   <string name="restore_error_message">Error restoring library</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -20,7 +20,7 @@
       android:defaultValue="true"/>
   <CheckBoxPreference
       android:key="reverse_sort_order"
-      android:title="Reverse sort order"
-      android:summary="Display newest season first"
+      android:title="@string/pref_reverse_sort_order"
+      android:summary="@string/pref_reverse_sort_order_summary"
       android:defaultValue="false"/>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,4 +18,9 @@
       android:dependency="pref_auto_refresh_enabled"
       android:title="@string/pref_auto_refresh_wifi_only_title"
       android:defaultValue="true"/>
+  <CheckBoxPreference
+      android:key="reverse_sort_order"
+      android:title="Reverse sort order"
+      android:summary="Display newest season first"
+      android:defaultValue="false"/>
 </PreferenceScreen>


### PR DESCRIPTION
I don't know Java really so critique is welcome, but this is an attempt at implementing #41 as a global preference. Tested fine on an Android 4.4.2 device.
